### PR TITLE
refactor std_dev function

### DIFF
--- a/percolation/src/stats.rs
+++ b/percolation/src/stats.rs
@@ -50,21 +50,16 @@ impl PercolationStats {
     }
 
     pub fn std_dev(&self) -> f64 {
-        match (self.mean(), self.xs.len()) {
-            (data_mean, count) if count > 0 => {
-                let variance = self
-                    .xs
-                    .iter()
-                    .map(|value| {
-                        let diff = data_mean - *value;
-                        diff * diff
-                    })
-                    .sum::<f64>()
-                    / count as f64;
-                variance.sqrt()
-            }
-            _ => 0.0,
-        }
+        let variance = self
+            .xs
+            .iter()
+            .map(|value| {
+                let diff = self.mean() - *value;
+                diff * diff
+            })
+            .sum::<f64>()
+            / self.xs.len() as f64;
+        variance.sqrt()
     }
 
     // high endpoint of 95% confidence interval


### PR DESCRIPTION
The match statement is unnecessary since we're not returning a result type and don't need to match for 0 len xs since we have to run at least 30 experiments.